### PR TITLE
Update skew-hook paper: published online first in AIHPD

### DIFF
--- a/_posts/papers/2024-09-26-skew-hook.md
+++ b/_posts/papers/2024-09-26-skew-hook.md
@@ -8,9 +8,9 @@ coauthors:
   - name: Leonid Petrov
 comments: false
 categories: blog math paper
-journal-ref: to appear in Annales de l'Institut Henri Poincaré D
+journal-ref: Annales de l'Institut Henri Poincaré D: Combinatorics, Physics and their Interactions (2026), published online first
 journal-year: 2026
-# journal-web: 
+journal-web: https://doi.org/10.4171/AIHPD/224
 image: __STORAGE_URL__/img/papers/YBE_YD.png
 image-alt: Yang-Baxter equation meets Young diagrams
 show-date: true


### PR DESCRIPTION
The Panova–Petrov skew hook-length paper is now published online first (10 Feb 2026, DOI 10.4171/AIHPD/224).

- `journal-ref` → full AIHPD name, "published online first" (was "to appear")
- `journal-web` → DOI link https://doi.org/10.4171/AIHPD/224

Post date and `journal-year: 2026` unchanged; volume/issue/pages to follow when assigned.